### PR TITLE
Fixed width of top dashboard graph to avoid overflow

### DIFF
--- a/openrunlog/templates/dashboard.html
+++ b/openrunlog/templates/dashboard.html
@@ -45,7 +45,7 @@
 
                 <div class="tab-pane active" id="thisweek1">
                     <h2>This Week ({{ week.distance }} miles, {{ week.pretty_time }})</h2>
-                    <figure style="width: 100%; height: 300px;" id="week"></figure>
+                    <figure style="width: 650px; height: 300px;" id="week"></figure>
                 </div>
             </div>
 


### PR DESCRIPTION
That was easier than expected...

Just had to set the width of the figure to be 650px rather than 100%.
