### PR TITLE
Fix recent run list

### DIFF
--- a/openrunlog/templates/dashboard.html
+++ b/openrunlog/templates/dashboard.html
@@ -132,6 +132,10 @@
 span.remove_run.label {
     margin-left: -26px;
 }
+div.recent_run {
+    height: 20px;
+    white-space: nowrap;
+}
 </style>
 
 <script src="{{ static_url('js/d3.v2.min.js') }}"></script>


### PR DESCRIPTION
- Move remove run label to the left of the list (stops the text from moving).
- Keep runs on one line. I don't think this is the best way, but it should work for now.
